### PR TITLE
LLVM patch to fix Windows ARM64 frame-record corruption and test

### DIFF
--- a/conda-recipes/llvm22-aarch64-windows-frame-record.patch
+++ b/conda-recipes/llvm22-aarch64-windows-frame-record.patch
@@ -1,0 +1,30 @@
+Fix Windows ARM64 frame-record corruption for windows-triple + ELF targets.
+
+llvm-project commit f4062100a0c7 (PR #156467) changed isTargetWindows() in
+AArch64FrameLowering.cpp to key off the object format (usesWindowsCFI())
+while AArch64RegisterInfo::getCalleeSavedRegs still selects the Windows CSR
+save order from the triple. For a windows-OS triple emitting ELF objects
+(llvmlite/numba MCJIT uses aarch64-pc-windows-msvc-elf), the two disagree:
+frame lowering applies non-Windows pairing rules to the Windows CSR order
+and pairs FP with a GPR other than LR whenever an odd number of GPR CSRs is
+saved and a frame pointer is required. Assert builds abort with
+"FrameRecord must be allocated together with LR"
+(computeCalleeSaveRegisterPairs); release builds emit a corrupted frame
+record. Revert the predicate to the triple-based subtarget check.
+
+diff --git a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
++++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+@@ -384,7 +384,11 @@
+ }
+
+ static bool isTargetWindows(const MachineFunction &MF) {
+-  return MF.getTarget().getMCAsmInfo()->usesWindowsCFI();
++  // Key off the OS in the triple, not the CFI directive style: a Windows
++  // target JITing ELF objects must still follow the Windows CSR pairing
++  // rules that getCalleeSavedRegs selected from the triple, otherwise FP
++  // is paired with a GPR other than LR and the frame record is corrupted.
++  return MF.getSubtarget<AArch64Subtarget>().isTargetWindows();
+ }
+
+ bool AArch64FrameLowering::hasSVECalleeSavesAboveFrameRecord(

--- a/conda-recipes/llvmdev/frame-record-min.ll
+++ b/conda-recipes/llvmdev/frame-record-min.ll
@@ -1,0 +1,5 @@
+target triple = "aarch64-pc-windows-msvc-elf"
+define void @f() "frame-pointer"="all" {
+  call void asm sideeffect "", "~{x19},~{x20},~{x21}"()
+  ret void
+}

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -11,6 +11,7 @@ source:
   - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "rc") }}.src.tar.xz
     sha256: {{ sha256_llvm }}
     patches:
+    - ../llvm22-aarch64-windows-frame-record.patch
     # - ../llvm15-remove-use-of-clonefile.patch
     # - ../llvm15-svml.patch
     # - ../compiler-rt-cfi-startproc-war.patch
@@ -52,9 +53,14 @@ requirements:
 test:
   files:
     - numba-3016.ll
+    - frame-record-min.ll
   commands:
     - $PREFIX/bin/llvm-config --libs                         # [not win]
     - $PREFIX/bin/llc -version                               # [not win]
+
+    # llvm22-aarch64-windows-frame-record.patch: FP/LR must be stored as an
+    # adjacent pair; unpatched assert builds abort, release builds split the pair
+    - '%LIBRARY_BIN%\llc frame-record-min.ll -o - | findstr /R /C:"stp.*x29, x30"'  # [win]
 
     - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
     - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]

--- a/conda-recipes/llvmdev_for_wheel/frame-record-min.ll
+++ b/conda-recipes/llvmdev_for_wheel/frame-record-min.ll
@@ -1,0 +1,5 @@
+target triple = "aarch64-pc-windows-msvc-elf"
+define void @f() "frame-pointer"="all" {
+  call void asm sideeffect "", "~{x19},~{x20},~{x21}"()
+  ret void
+}

--- a/conda-recipes/llvmdev_for_wheel/meta.yaml
+++ b/conda-recipes/llvmdev_for_wheel/meta.yaml
@@ -12,6 +12,7 @@ source:
   - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "rc") }}.src.tar.xz
     sha256: {{ sha256_llvm }}
     patches:
+    - ../llvm22-aarch64-windows-frame-record.patch
     # - ../llvm15-clear-gotoffsetmap.patch
     # - ../llvm15-remove-use-of-clonefile.patch
     # - ../llvm15-svml.patch
@@ -54,12 +55,15 @@ requirements:
     - zlib      # [not win]
 
 test:
-  # Unused test file
-  # files:
-  #   - numba-3016.ll
+  files:
+    - frame-record-min.ll
   commands:
     - $PREFIX/bin/llvm-config --libs                         # [not win]
     - $PREFIX/bin/llc -version                               # [not win]
+
+    # llvm22-aarch64-windows-frame-record.patch: FP/LR must be stored as an
+    # adjacent pair; unpatched assert builds abort, release builds split the pair
+    - '%LIBRARY_BIN%\llc frame-record-min.ll -o - | findstr /R /C:"stp.*x29, x30"'  # [win]
 
     - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
     - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]


### PR DESCRIPTION
llvm-project commit f4062100a0c7 (PR #156467) changed isTargetWindows() in
AArch64FrameLowering.cpp to key off the object format (usesWindowsCFI())
while AArch64RegisterInfo::getCalleeSavedRegs still selects the Windows CSR
save order from the triple. For a windows-OS triple emitting ELF objects
(llvmlite/numba MCJIT uses aarch64-pc-windows-msvc-elf), the two disagree:
frame lowering applies non-Windows pairing rules to the Windows CSR order
and pairs FP with a GPR other than LR whenever an odd number of GPR CSRs is
saved and a frame pointer is required. Assert builds abort with
"FrameRecord must be allocated together with LR"
(computeCalleeSaveRegisterPairs); release builds emit a corrupted frame
record. Revert the predicate to the triple-based subtarget check.